### PR TITLE
Fix hotkeys without modifiers on windows

### DIFF
--- a/pyqtkeybind/win/keybindutil.py
+++ b/pyqtkeybind/win/keybindutil.py
@@ -13,7 +13,7 @@ def keys_from_string(keys):
     ks = keysequence[0]
 
     # Calculate the modifiers
-    mods = Qt.NoModifier
+    mods = 0
     qtmods = Qt.NoModifier
     if (ks & Qt.ShiftModifier == Qt.ShiftModifier):
         mods |= ModsTbl.index(Qt.ShiftModifier)


### PR DESCRIPTION
If no modifiers are passed then mods is left as a `PyQt5.QtCore.Qt.KeyboardModifier` instead of `int`. Which causes the handler to be unable find the callback.