### PR TITLE
Add QtPy / PySide2 / PySide6 / PyQt6 support to Windows code; update to Python 3.8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# PyCharm
+.idea

--- a/pyqtkeybind/win/keybindutil.py
+++ b/pyqtkeybind/win/keybindutil.py
@@ -1,53 +1,74 @@
-# -*- coding: utf-8 -*-
-
 import ctypes
 from ctypes import windll
-from PyQt5.QtGui import QKeySequence
-from PyQt5.QtCore import Qt
+from typing import Tuple
+
+import qtpy
+from qtpy.QtGui import QKeySequence
+from qtpy.QtCore import Qt
 
 from .keycodes import KeyTbl, ModsTbl
 
 
-def keys_from_string(keys):
+def keys_from_string(keys: str) -> Tuple[int, int]:
+
     keysequence = QKeySequence(keys)
-    ks = keysequence[0]
+    if qtpy.QT5:
+        ks = keysequence[0]
 
-    # Calculate the modifiers
-    mods = 0
-    qtmods = Qt.NoModifier
-    if (ks & Qt.ShiftModifier == Qt.ShiftModifier):
-        mods |= ModsTbl.index(Qt.ShiftModifier)
-        qtmods |= Qt.ShiftModifier.real
-    if (ks & Qt.AltModifier == Qt.AltModifier):
-        mods |= ModsTbl.index(Qt.AltModifier)
-        qtmods |= Qt.AltModifier.real
-    if (ks & Qt.ControlModifier == Qt.ControlModifier):
-        mods |= ModsTbl.index(Qt.ControlModifier)
-        qtmods |= Qt.ControlModifier.real
+        # Calculate the modifiers
+        mods = 0
+        qtmods = Qt.NoModifier
+        if ks & Qt.ShiftModifier == Qt.ShiftModifier:
+            mods |= ModsTbl.index(Qt.ShiftModifier)
+            qtmods |= int(Qt.ShiftModifier)
+        if ks & Qt.AltModifier == Qt.AltModifier:
+            mods |= ModsTbl.index(Qt.AltModifier)
+            qtmods |= int(Qt.AltModifier)
+        if ks & Qt.ControlModifier == Qt.ControlModifier:
+            mods |= ModsTbl.index(Qt.ControlModifier)
+            qtmods |= int(Qt.ControlModifier)
 
-    # Calculate the keys
-    qtkeys = ks ^ qtmods
+        # Calculate the keys
+        qtkeys = ks ^ qtmods
+
+        # Pyside2 PySide2.QtCore.Qt.KeyboardModifiers need to be cast to type int
+        calculated_keys = qtkeys if qtpy.API == "pyqt5" else int(qtkeys)
+
+    else:
+        assert qtpy.QT6
+        ks_comb = keysequence[0]
+        ks_modifiers = ks_comb.keyboardModifiers()
+        calculated_keys = ks_comb.key()
+
+        # Calculate the modifiers
+        mods = 0
+        if ks_modifiers & Qt.ShiftModifier:
+            mods |= ModsTbl.index(Qt.ShiftModifier)
+        if ks_modifiers & Qt.AltModifier:
+            mods |= ModsTbl.index(Qt.AltModifier)
+        if ks_modifiers & Qt.ControlModifier:
+            mods |= ModsTbl.index(Qt.ControlModifier)
+
     try:
-        keys = KeyTbl[qtkeys]
+        keys = KeyTbl[calculated_keys]
         if keys == 0:
-            keys = _get_virtual_key(qtkeys)
+            keys = _get_virtual_key(calculated_keys)
     except ValueError:
-        keys = _get_virtual_key(qtkeys)
+        keys = _get_virtual_key(calculated_keys)
     except IndexError:
-        keys = KeyTbl.index(qtkeys)
+        keys = KeyTbl.index(calculated_keys)
         if keys == 0:
-            keys = _get_virtual_key(qtkeys)
-
+            keys = _get_virtual_key(calculated_keys)
 
     return mods, keys
 
 
-def _get_virtual_key(qtkeys):
+def _get_virtual_key(qtkeys: int) -> int:
     """Use the system keyboard layout to retrieve the virtual key.
 
     Fallback when we're unable to find a keycode in the mappings table.
     """
-    user32 = ctypes.WinDLL('user32', use_last_error=True)
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
     thread_id = 0
 
     # Key table doesn't have an entry for this keycode
@@ -58,6 +79,6 @@ def _get_virtual_key(qtkeys):
         keyboard_layout = user32.GetKeyboardLayout(0x409)
         virtual_key = windll.user32.VkKeyScanExW(qtkeys, keyboard_layout)
     # Key code is the low order byte
-    keys = virtual_key & 0xff
+    keys = virtual_key & 0xFF
 
     return keys

--- a/pyqtkeybind/win/keycodes.py
+++ b/pyqtkeybind/win/keycodes.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Source: Qt source code
 # https://raw.githubusercontent.com/qtproject/qtbase/dev/src/plugins/platforms/windows/qwindowskeymapper.cpp
 # flake8: noqa
 
-from PyQt5 import QtCore
+from qtpy import QtCore
 
 # Key translation ---------------------------------------------------------------------[ start ] --
 # Meaning of values:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Setup for pyqtkeybind."""
 
 import io
@@ -15,12 +14,12 @@ DESCRIPTION = "Global hotkey bindings for Windows and Linux for PyQt apps"
 URL = "https://github.com/codito/pyqtkeybind"
 EMAIL = "arun@codito.in"
 AUTHOR = "Arun Mahapatra"
-VERSION = (0, 0, 9)
+VERSION = (0, 1, 0)
 
 # Dependencies required for execution
 REQUIRED = [
     "xcffib; sys_platform != 'win32'",
-    "PyQt5"
+    "qtpy"
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -88,8 +87,11 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Intended Audience :: Developers",


### PR DESCRIPTION
- The Windows specific code now works with QtPy / PySide2 / PySide6 / PyQt6, in addition to the existing support for PyQt5.
- Bumped the minimum python version to 3.8, allowing the use of python typing
- Reworked the sample hotkey application a little
- Reformatted code I edited using [Black](https://github.com/psf/black)
- Removed reference to UTF header in the code (no longer needed)
- Ported a fix in `unregister_hotkey` from [here](https://github.com/elecfrog/pyqtkeybind-PySide6/blob/master/pyqtkeybind/win/__init__.py).

The Linux code will require some thought. I have not touched it yet. With X11 now depreciated, and Wayland the future, Qt6 has already dropped some X11 compatibility code, affecting code like `QX11Info.appRootWindow()` (that does not exist in Qt6). Hard to know how much demand there is for Qt6 + X11. As for Wayland, that looks complicated. For example, there is some discussion [here](https://github.com/moses-palmer/pynput/issues/184) (it might be out of date already).